### PR TITLE
Update to 3.31.8

### DIFF
--- a/rpm/0001-Revert-Autogen-Reenable-passing-compiler-implicit-in.patch
+++ b/rpm/0001-Revert-Autogen-Reenable-passing-compiler-implicit-in.patch
@@ -13,7 +13,7 @@ This reverts commit 03dbb62d31d4a115fed09049cf6995ce89d2fabe.
  4 files changed, 6 insertions(+), 12 deletions(-)
 
 diff --git a/Source/cmQtAutoGenInitializer.cxx b/Source/cmQtAutoGenInitializer.cxx
-index ee53a8ec73575c3ef1ee8ad07c58df1a4356d2c9..ca9e3a60726c5b000c4437ce87bfd1444e403b44 100644
+index 5810d03713b9e3adcbb0053a13b22051546c5750..0ef6b260b6ac86f59ffcdfd72640231ea19ec644 100644
 --- a/Source/cmQtAutoGenInitializer.cxx
 +++ b/Source/cmQtAutoGenInitializer.cxx
 @@ -735,7 +735,10 @@ bool cmQtAutoGenInitializer::InitMoc()
@@ -67,10 +67,10 @@ index 87fd4947892d0cabd135c5edc618530b590f03b9..53000aa79c7fc4d2574f37597fd64fc5
  #ifndef Q_OS_MAC
    void MacNotDef();
 diff --git a/Tests/QtAutogen/Tests.cmake b/Tests/QtAutogen/Tests.cmake
-index d37be1c13485b34c0565bcb96dfb9c86c35f94b1..8ab40c54aef3687a021f3c593967cdfdb1af90b6 100644
+index bd0c598495a2cbcc3eb8ee8e3329c0f1ab84fe95..516d57aaadc377225c3d313beddba62f927ea687 100644
 --- a/Tests/QtAutogen/Tests.cmake
 +++ b/Tests/QtAutogen/Tests.cmake
-@@ -58,7 +58,8 @@ endif()
+@@ -56,7 +56,8 @@ endif()
  # Qt5 and Qt6 only tests
  if(QT_TEST_VERSION GREATER 4)
    ADD_AUTOGEN_TEST(MocMacroName mocMacroName)

--- a/rpm/0002-cmFileAPI-Allow-to-control-the-file-API-path.patch
+++ b/rpm/0002-cmFileAPI-Allow-to-control-the-file-API-path.patch
@@ -9,10 +9,10 @@ Allow postprocessing of the reply before the IDE gets to it.
  1 file changed, 6 insertions(+), 1 deletion(-)
 
 diff --git a/Source/cmFileAPI.cxx b/Source/cmFileAPI.cxx
-index d4a717586df3869c5bdca444a3a43484b4c43f56..a6412bc5e268e3c96fdab60bb84e60fc69d1d1cb 100644
+index 1f15612210e4efa3b7426ee4ae0b8ed7277831c6..b28d41c30c78a390d2567e926f26468421cd2d0d 100644
 --- a/Source/cmFileAPI.cxx
 +++ b/Source/cmFileAPI.cxx
-@@ -28,8 +28,13 @@
+@@ -32,8 +32,13 @@
  cmFileAPI::cmFileAPI(cmake* cm)
    : CMakeInstance(cm)
  {
@@ -22,8 +22,8 @@ index d4a717586df3869c5bdca444a3a43484b4c43f56..a6412bc5e268e3c96fdab60bb84e60fc
 +      prefix = ".cmake";
 +
    this->APIv1 =
--    this->CMakeInstance->GetHomeOutputDirectory() + "/.cmake/api/v1";
-+    this->CMakeInstance->GetHomeOutputDirectory() + "/" + prefix + "/api/v1";
+-    cmStrCat(this->CMakeInstance->GetHomeOutputDirectory(), "/.cmake/api/v1");
++    cmStrCat(this->CMakeInstance->GetHomeOutputDirectory(), "/", prefix, "/api/v1");
  
-   Json::CharReaderBuilder rbuilder;
-   rbuilder["collectComments"] = false;
+   if (cm::optional<std::string> cmakeConfigDir =
+         cmSystemTools::GetCMakeConfigDirectory()) {

--- a/rpm/0003-cmCTestCurl-Avoid-using-undocumented-type-for-CURLOP.patch
+++ b/rpm/0003-cmCTestCurl-Avoid-using-undocumented-type-for-CURLOP.patch
@@ -1,0 +1,30 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Brad King <brad.king@kitware.com>
+Date: Tue, 2 Sep 2025 11:41:10 -0400
+Subject: [PATCH] cmCTestCurl: Avoid using undocumented type for
+ CURLOPT_PROXYTYPE values
+
+Since upstream curl commit `1a12663d06` (CURLOPT: bump `CURLPROXY_*`
+enums to `long`, drop casts, 2025-07-28), the `CURLPROXY_*` constants
+are integer literals instead of `enum curl_proxytype`.  It turns out
+that `curl_easy_setopt` has always expected a `long` anyway, and that
+`curl_proxytype` is not documented for public use.
+
+Fixes: #27178
+---
+ Source/CTest/cmCTestCurl.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/Source/CTest/cmCTestCurl.h b/Source/CTest/cmCTestCurl.h
+index 7836f4b9c78a1d103eee515d618856a6712b4480..9113890b5a12cb157b691b66d96e25d0fd4b50ef 100644
+--- a/Source/CTest/cmCTestCurl.h
++++ b/Source/CTest/cmCTestCurl.h
+@@ -52,7 +52,7 @@ private:
+   std::vector<std::string> HttpHeaders;
+   std::string HTTPProxyAuth;
+   std::string HTTPProxy;
+-  curl_proxytype HTTPProxyType;
++  long HTTPProxyType;
+   bool UseHttp10 = false;
+   bool Quiet = false;
+   int TimeOutSeconds = 0;

--- a/rpm/cmake.spec
+++ b/rpm/cmake.spec
@@ -1,7 +1,7 @@
 %global major_version 3
 
 Name:           cmake
-Version:        3.30.3
+Version:        3.31.8
 Release:        1
 License:        BSD
 Summary:        Cross-platform make system
@@ -12,6 +12,7 @@ Source2:        %{name}.attr
 Source3:        %{name}.prov
 Patch0:         0001-Revert-Autogen-Reenable-passing-compiler-implicit-in.patch
 Patch1:         0002-cmFileAPI-Allow-to-control-the-file-API-path.patch
+Patch2:         0003-cmCTestCurl-Avoid-using-undocumented-type-for-CURLOP.patch
 BuildRequires:  expat-devel
 BuildRequires:  bzip2-devel
 BuildRequires:  xz-devel


### PR DESCRIPTION
Backport patch to fix ctest builds with curl 8.16.